### PR TITLE
Fixed breaking changes for using Socket.Io 3.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "node-red-contrib-socketio",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Implementation for Node-RED of a SocketIO Sever",
   "dependencies": {
-   "socket.io": ">=2.2.0"
+   "socket.io": ">=3.1.0"
   },
   "node-red": {
     "nodes": {

--- a/socketio.html
+++ b/socketio.html
@@ -33,7 +33,7 @@
 <script type="text/x-red" data-template-name="socketio-config">
     <div class="form-row">
 		<input type="checkbox" id="node-config-input-bindToNode" style="display: inline-block; width: auto; vertical-align: top;">
-		<label for="node-config-input-bindToNode" style="width: auto"> Bind to Node-red Istance</label>
+		<label for="node-config-input-bindToNode" style="width: auto"> Bind to Node-red Instance</label>
 		<div id="node-row-bindToNode" class="hide">
 			<label for="node-config-input-port"><i class="fa fa-terminal"></i> Port</label>
 			<input type="text" id="node-config-input-port">

--- a/socketio.js
+++ b/socketio.js
@@ -1,6 +1,5 @@
 /**
  * Copyright Gallimberti Telemaco 02/02/2017
- * Modified by Phil Cazella 03/20/2021 
  **/
 
 module.exports = function(RED) {

--- a/socketio.js
+++ b/socketio.js
@@ -1,15 +1,15 @@
 /**
  * Copyright Gallimberti Telemaco 02/02/2017
+ * Modified by Phil Cazella 03/20/2021 
  **/
 
 module.exports = function(RED) {
-  var Server = require("socket.io");
+  const { Server } = require("socket.io");
   var io;
   var customProperties = {};
 
   function socketIoConfig(n) {
     RED.nodes.createNode(this, n);
-    // node-specific code goes here
     var node = this;
     this.port = n.port || 80;
     this.sendClient = n.sendClient;
@@ -30,43 +30,40 @@ module.exports = function(RED) {
     node.log("Created server " + bindOn);
 
     node.on("close", function() {
-      //node.log("Closing server");
       io.close();
-      //node.log("Closed server");
     });
   }
 
   function socketIoIn(n) {
     RED.nodes.createNode(this, n);
-    // node-specific code goes here
     var node = this;
     this.name = n.name;
     this.server = RED.nodes.getNode(n.server);
     this.rules = n.rules || [];
 
     this.specialIOEvent = [
+	// Events emitted by the Manager:
+      { v: "open" },
       { v: "error" },
+	  { v: "close" },
+	  { v: "ping" },
+	  { v: "packet" },
+	  { v: "reconnect_attempt" },
+	  { v: "reconnect" },
+	  { v: "reconnect_error" },
+	  { v: "reconnect_failed" },
+	  
+	  // Events emitted by the Socket:
       { v: "connect" },
-      { v: "disconnect" },
-      { v: "disconnecting" },
-      { v: "newListener" },
-      { v: "removeListener" },
-      { v: "ping" },
-      { v: "pong" }
+	  { v: "connect_error" },
+      { v: "disconnect" }
     ];
 
-    //add listener to socket, for now return nothing
     function addListener(socket, val, i) {
       socket.on(val.v, function(msgin) {
-        //node.log("Registered new " + val.v + " event");
         var msg = {};
         RED.util.setMessageProperty(msg, "payload", msgin, true);
         RED.util.setMessageProperty(msg, "socketIOEvent", val.v, true);
-        //Throw error  TypeError: Cannot set property listening of #<Server> which has only a getter
-        // this is to solve
-        //messages into node-red are cloned when they are send
-        //so we can't sand socket... =(
-        //RED.util.setMessageProperty(msg, "socket", socket, true);
         RED.util.setMessageProperty(msg, "socketIOId", socket.id, true);
         if (
           customProperties[RED.util.getMessageProperty(msg, "socketIOId")] !=
@@ -84,7 +81,6 @@ module.exports = function(RED) {
     }
 
     io.on("connection", function(socket) {
-      //node.log("New connection");
       node.rules.forEach(function(val, i) {
         addListener(socket, val, i);
       });
@@ -97,26 +93,11 @@ module.exports = function(RED) {
 
   function socketIoOut(n) {
     RED.nodes.createNode(this, n);
-    // node-specific code goes here
     var node = this;
     this.name = n.name;
     this.server = RED.nodes.getNode(n.server);
 
     node.on("input", function(msg) {
-      // do something with 'msg'
-      //node.log("Ecoing message");
-      //console.log(customProperties);
-      //console.log(customProperties[RED.util.getMessageProperty(msg,"socketIOId")]);
-      /*console.log(io.sockets.sockets[RED.util.getMessageProperty(msg,"socketIOId")]);
-			if(Object.prototype.toString.call(io.sockets.sockets[RED.util.getMessageProperty(msg,"socketIOId")]) === '[object Array]')
-			{
-				console.log("io.sockets.sockets is an array!! urray!!");
-			}
-			else
-			{
-				console.log("io.sockets.sockets is NOT an array!");
-				console.log(Object.prototype.toString.call(io.sockets.sockets[RED.util.getMessageProperty(msg,"socketIOId")]));
-			}*/
       //check if we need to add properties
       if (RED.util.getMessageProperty(msg, "socketIOAddStaticProperties")) {
         //check if we have already added some properties for this socket
@@ -128,7 +109,6 @@ module.exports = function(RED) {
           var keys = Object.getOwnPropertyNames(
             RED.util.getMessageProperty(msg, "socketIOAddStaticProperties")
           );
-          //console.log(keys);
           var tmp =
             customProperties[RED.util.getMessageProperty(msg, "socketIOId")];
           for (var i = 0; i < keys.length; i++) {
@@ -137,9 +117,6 @@ module.exports = function(RED) {
               "socketIOAddStaticProperties"
             )[keys[i]];
           }
-          //console.log("-After add or modify-");
-          //console.log(customProperties);
-          //console.log("---------------------");
         } else {
           //add new properties
           customProperties[
@@ -148,86 +125,79 @@ module.exports = function(RED) {
         }
       }
 
+	
       switch (RED.util.getMessageProperty(msg, "socketIOEmit")) {
         case "broadcast.emit":
           //Return to all but the caller
           if (
-            io.sockets.sockets[RED.util.getMessageProperty(msg, "socketIOId")]
+            io.sockets.sockets.get(RED.util.getMessageProperty(msg, "socketIOId"))
           ) {
-            io.sockets.sockets[
+            io.sockets.sockets.get(
               RED.util.getMessageProperty(msg, "socketIOId")
-            ].broadcast.emit(msg.socketIOEvent, msg.payload);
+            ).broadcast.emit(msg.socketIOEvent, msg.payload);
           }
-          //console.log("broadcast.emit");
           break;
         case "emit":
           //Return only to the caller
           if (
-            io.sockets.sockets[RED.util.getMessageProperty(msg, "socketIOId")]
+            io.sockets.sockets.get(RED.util.getMessageProperty(msg, "socketIOId"))
           ) {
-            io.sockets.sockets[
+            io.sockets.sockets.get(
               RED.util.getMessageProperty(msg, "socketIOId")
-            ].emit(msg.socketIOEvent, msg.payload);
+            ).emit(msg.socketIOEvent, msg.payload);
           }
-          //console.log("emit");
           break;
         case "room":
           //emit to all
           if (msg.room) {
             io.to(msg.room).emit(msg.socketIOEvent, msg.payload);
           }
-          //console.log("io.to.emit", msg.room);
           break;
         default:
           //emit to all
           io.emit(msg.socketIOEvent, msg.payload);
-        //console.log("io.emit");
       }
     });
   }
 
   function socketIoJoin(n) {
     RED.nodes.createNode(this, n);
-    // node-specific code goes here
     var node = this;
     this.name = n.name;
     this.server = RED.nodes.getNode(n.server);
 
     node.on("input", function(msg) {
-      if (io.sockets.sockets[RED.util.getMessageProperty(msg, "socketIOId")]) {
-        io.sockets.sockets[RED.util.getMessageProperty(msg, "socketIOId")].join(
+      if (io.sockets.sockets.get(RED.util.getMessageProperty(msg, "socketIOId"))) {
+        io.sockets.sockets.get(RED.util.getMessageProperty(msg, "socketIOId")).join(
           msg.payload.room
         );
         node.send(msg);
       }
     });
   }
+  
   function socketIoRooms(n) {
     RED.nodes.createNode(this, n);
-    // node-specific code goes here
     var node = this;
     this.name = n.name;
     this.server = RED.nodes.getNode(n.server);
 
     node.on("input", function(msg) {
-      // if(io.sockets.sockets[RED.util.getMessageProperty(msg,"socketIOId")]){
-    //   console.log(io.sockets.adapter.rooms);
       node.send({ payload: io.sockets.adapter.rooms });
-      // }
     });
   }
+  
   function socketIoLeave(n) {
     RED.nodes.createNode(this, n);
-    // node-specific code goes here
     var node = this;
     this.name = n.name;
     this.server = RED.nodes.getNode(n.server);
 
     node.on("input", function(msg) {
-      if (io.sockets.sockets[RED.util.getMessageProperty(msg, "socketIOId")]) {
-        io.sockets.sockets[
+      if (io.sockets.sockets.get(RED.util.getMessageProperty(msg, "socketIOId"))) {
+        io.sockets.sockets.get(
           RED.util.getMessageProperty(msg, "socketIOId")
-        ].leave(msg.payload.room);
+        ).leave(msg.payload.room);
       }
     });
   }


### PR DESCRIPTION
Copy from wperw/node-red-contrib-socketio/pull/13

Fixed breaking changes for using Socket.Io 3.0+

https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#ES-modules-syntax

Changed Server instantiation to use ES Modules syntax
https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#No-more-%E2%80%9Cpong%E2%80%9D-event-for-retrieving-latency

Updated list of special events for Socket.IO v3
https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#Namespace-connected-is-renamed-to-Namespace-sockets-and-is-now-a-Map

Changed all map[str] references to map.get(str)
Removed commented out console.log() statements